### PR TITLE
feat: add integrity checks and allow non-sudo installations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,14 @@
+name: Test
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - run: chmod +x tests.sh && ./tests.sh

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Manuel Spagnolo
+Copyright (c) 2026 Manuel Spagnolo
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ Optionally, programs can be accompained by a man page, whose naming convention f
 Executing the following command will install latest version of `mybin` (for example, downloading `mybin-linux-amd64`)
 
 ```sh
-curl -s https://shikaan.github.io/sup/install | REPO=myuser/mybin sh -
+curl -s https://shikaan.github.io/sup/install | REPO=owner/repo sh -
 ```
 
 The name of the binary is inferred from the `REPO` variable. You can override it with `BIN`
 
 ```sh
-curl -s https://shikaan.github.io/sup/install | REPO=myuser/myrepo BIN=mybin sh -
+curl -s https://shikaan.github.io/sup/install | REPO=owner/repo BIN=mybin sh -
 ```
 
 ### Uninstall
@@ -36,13 +36,13 @@ curl -s https://shikaan.github.io/sup/install | REPO=myuser/myrepo BIN=mybin sh 
 Same as above, but it will uninstall `mybin`
 
 ```sh
-curl -s https://shikaan.github.io/sup/uninstall | REPO=myuser/mybin sh -
+curl -s https://shikaan.github.io/sup/uninstall | REPO=owner/repo sh -
 ```
 
 Or, again, with the `BIN` override
 
 ```sh
-curl -s https://shikaan.github.io/sup/uninstall | REPO=myuser/myrepo BIN=mybin sh -
+curl -s https://shikaan.github.io/sup/uninstall | REPO=owner/repo BIN=mybin sh -
 ```
 
 ## 📝 Example

--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ Optionally, programs can be accompained by a man page, whose naming convention f
 Executing the following command will install latest version of `mybin` (for example, downloading `mybin-linux-amd64`)
 
 ```sh
-sudo sh -c "curl -s https://shikaan.github.io/sup/install | REPO=myuser/mybin sh -"
+curl -s https://shikaan.github.io/sup/install | REPO=myuser/mybin sh -
 ```
 
 The name of the binary is inferred from the `REPO` variable. You can override it with `BIN`
 
 ```sh
-sudo sh -c "curl -s https://shikaan.github.io/sup/install | REPO=myuser/myrepo BIN=mybin sh -"
+curl -s https://shikaan.github.io/sup/install | REPO=myuser/myrepo BIN=mybin sh -
 ```
 
 ### Uninstall
@@ -36,13 +36,13 @@ sudo sh -c "curl -s https://shikaan.github.io/sup/install | REPO=myuser/myrepo B
 Same as above, but it will uninstall `mybin`
 
 ```sh
-sudo sh -c "curl -s https://shikaan.github.io/sup/uninstall | REPO=myuser/mybin sh -"
+curl -s https://shikaan.github.io/sup/uninstall | REPO=myuser/mybin sh -
 ```
 
 Or, again, with the `BIN` override
 
 ```sh
-sudo sh -c "curl -s https://shikaan.github.io/sup/uninstall | REPO=myuser/myrepo BIN=mybin sh -"
+curl -s https://shikaan.github.io/sup/uninstall | REPO=myuser/myrepo BIN=mybin sh -
 ```
 
 ## 📝 Example

--- a/install
+++ b/install
@@ -1,38 +1,52 @@
 #!/usr/bin/env sh
 
-get_architecture () {
-  arch="$(uname -m)"
+set -e
 
-  if [ "$arch" = "x86_64" ]; then
-    echo "amd64"
-  else
-    echo "$arch"
-  fi
-}
+BIN_ROOT="$HOME/.local/bin"
+MAN_ROOT="$HOME/.local/share/man"
+MAN_SECTION="1"
 
-get_os () {
-  uname | tr '[:upper:]' '[:lower:]'
-}
-
-print_usage () {
-  echo ""
-  echo "Usage: sudo REPO=org/repo BIN=name $0"
-}
-
-OS=$(get_os)
-ARCH=$(get_architecture)
-HAS_WGET=$(which wget)
-
-if [ "$(id -u)" -ne 0 ]; then
-  echo "Installation needs to be run as super user."
-  print_usage
+error() {
+  echo $1 >&2
+  echo "" >&2
+  echo "Usage: REPO=owner/repo BIN=name $0" >&2
   exit 1
-fi
+}
 
 if [ -z "${REPO}" ]; then
-  echo "REPO should be in the form of 'organization/repo', got '${REPO}'."
-  print_usage
-  exit 1
+  error "REPO should be in the form of 'owner/repo'."
+fi
+
+RELEASE_URL="https://github.com/${REPO}/releases/latest"
+
+OS=""
+case "$(uname -s)" in
+    Darwin) OS="darwin" ;;
+    Linux) OS="linux" ;;
+    MINGW*|MSYS*|CYGWIN*) error "Windows is not supported by this script. You can download the .exe at ${RELEASE_URL}.";;
+    *) error "Unsupported operating system: $(uname -s). See ${RELEASE_URL} for supported platforms.";;
+esac
+
+ARCH=""
+case "$(uname -m)" in
+    x86_64|amd64) ARCH="amd64" ;;
+    arm64|aarch64) ARCH="arm64" ;;
+    *) error "Unsupported architecture: $(uname -m). See ${RELEASE_URL} for supported platforms.";;
+esac
+
+DOWNLOAD_CMD=""
+API_CMD=""
+HEAD_CMD=""
+if command -v curl >/dev/null 2>&1; then
+    DOWNLOAD_CMD="curl -sfLo"
+    API_CMD="curl -s"
+    HEAD_CMD="curl -sfLI"
+elif command -v wget >/dev/null 2>&1; then
+    DOWNLOAD_CMD="wget -q -O"
+    API_CMD="wget -qO-"
+    HEAD_CMD="wget --spider --max-redirect=20 -q"
+else
+    error "Either curl or wget is required but neither is installed"
 fi
 
 if [ -z "${BIN}" ]; then
@@ -40,50 +54,100 @@ if [ -z "${BIN}" ]; then
 fi
 
 # where to install the binary
-DESTINATION="/usr/local/bin/${BIN}"
+DESTINATION="${BIN_ROOT}/${BIN}"
 # name of the hosted binary
 ARTIFACT_NAME="${BIN}-${OS}-${ARCH}"
 # complete URL where the binary is hosted
-URL="https://github.com/${REPO}/releases/latest/download/${ARTIFACT_NAME}"
+BIN_URL="${RELEASE_URL}/download/${ARTIFACT_NAME}"
+# API URL to fetch the digest
+API_URL="https://api.github.com/repos/${REPO}/releases/latest"
 
 echo "Starting installation of ${BIN}"
 
-echo "> Downloading binary ${ARTIFACT_NAME}..."
-if [ -z "$HAS_WGET" ]; then
-  curl -sfLo "${DESTINATION}" "${URL}"
+echo "  Downloading ${ARTIFACT_NAME}..."
+${DOWNLOAD_CMD} "${DESTINATION}" "${BIN_URL}"
+echo "  Downloading ${ARTIFACT_NAME}... OK"
+
+echo "  Verifying integrity..."
+DIGEST=$(${API_CMD} ${API_URL} | \
+    grep -A 50 "\"name\": \"${ARTIFACT_NAME}\"" | \
+    grep '"digest":' | \
+    head -n 1 | \
+    sed 's/.*"digest": "\([^"]*\)".*/\1/'
+)
+
+HASH=""
+if command -v sha256sum >/dev/null 2>&1; then
+  HASH=$(sha256sum "${DESTINATION}" | awk '{print $1}')
+elif command -v shasum >/dev/null 2>&1; then
+  HASH=$(shasum -a 256 "${DESTINATION}" | awk '{print $1}')
 else
-  wget -q -O "${DESTINATION}" "${URL}"
+  error "Neither sha256sum nor shasum found"
 fi
 
-echo "> Setting permissions..."
+if [ "sha256:$HASH" = "$DIGEST" ]; then
+  echo "  Verifying integrity... OK"
+else
+  rm ${DESTINATION}
+  error "Checksum mismatch. Please reach out at https://github.com/${REPO}/issues to get help"
+fi
+
+
+echo "  Setting permissions..."
 chmod u+x "${DESTINATION}"
 chown "$(logname)" "${DESTINATION}"
+echo "  Setting permissions... OK"
 
 # install the manpage in the first section (user commands and tools)
-MAN_ROOT="/usr/local/share/man/man1"
 # consequently expect file name to end with .1
-MAN_ARTIFACT_NAME="${BIN}.1"
-MAN_DESTINATION="${MAN_ROOT}/${MAN_ARTIFACT_NAME}"
+MAN_ARTIFACT_NAME="${BIN}.${MAN_SECTION}"
+MAN_DESTINATION="${MAN_ROOT}/man${MAN_SECTION}/${MAN_ARTIFACT_NAME}"
 # fetch the man from the same place as the binary
-MAN_URL="https://github.com/${REPO}/releases/latest/download/${MAN_ARTIFACT_NAME}"
+MAN_URL="${RELEASE_URL}/download/${MAN_ARTIFACT_NAME}"
 
 NO_MANPAGE=0
-if [ -z "$HAS_WGET" ]; then
-  curl -sfLI "${MAN_URL}" > /dev/null
-  NO_MANPAGE=$?
-else
-  wget --spider --max-redirect=20 -q "${MAN_URL}"
-  NO_MANPAGE=$?
+if ! $HEAD_CMD "${MAN_URL}" > /dev/null; then
+  NO_MANPAGE=1
 fi
 
 if [ "$NO_MANPAGE" -eq 0 ]; then
-  echo "> Downloading man page ${MAN_ARTIFACT_NAME}..."
+  echo "  Downloading man page ${MAN_ARTIFACT_NAME}..."
   mkdir -p "$MAN_ROOT"
-  if [ -z "$HAS_WGET" ]; then
-    curl -sfLo "${MAN_DESTINATION}" "${MAN_URL}"
-  else
-    wget -q -O "${MAN_DESTINATION}" "${MAN_URL}"
+  ${DOWNLOAD_CMD} "${MAN_DESTINATION}" "${MAN_URL}"
+  echo "  Downloading man page ${MAN_ARTIFACT_NAME}... OK"
+fi
+
+echo "  Updating shell configuration..."
+SHELL_CONFIG=""
+PATH_LINE=""
+MANPATH_LINE=""
+
+if [ -f "$HOME/.config/fish/config.fish" ]; then
+  SHELL_CONFIG="$HOME/.config/fish/config.fish"
+  PATH_LINE="fish_add_path -g ${BIN_ROOT}"
+  MANPATH_LINE="set -gx MANPATH ${MAN_ROOT} \$MANPATH"
+elif [ -f "$HOME/.zshrc" ]; then
+  SHELL_CONFIG="$HOME/.zshrc"
+  PATH_LINE="export PATH=\"${BIN_ROOT}:\$PATH\""
+  MANPATH_LINE="export MANPATH=\"${MAN_ROOT}:\$MANPATH\""
+elif [ -f "$HOME/.bashrc" ]; then
+  SHELL_CONFIG="$HOME/.bashrc"
+  PATH_LINE="export PATH=\"${BIN_ROOT}:\$PATH\""
+  MANPATH_LINE="export MANPATH=\"${MAN_ROOT}:\$MANPATH\""
+fi
+
+if [ -n "$SHELL_CONFIG" ]; then
+  if ! grep -q "${BIN_ROOT}" "$SHELL_CONFIG"; then
+    echo "" >> "$SHELL_CONFIG"
+    echo "# Added by ${BIN} installer" >> "$SHELL_CONFIG"
+    echo "$PATH_LINE" >> "$SHELL_CONFIG"
+  fi
+
+  if [ "$NO_MANPAGE" -eq 0 ] && ! grep -q "${MAN_ROOT}" "$SHELL_CONFIG"; then
+    echo "# Added by ${BIN} installer" >> "$SHELL_CONFIG"
+    echo "$MANPATH_LINE" >> "$SHELL_CONFIG"
   fi
 fi
+echo "  Updating shell configuration... OK"
 
 echo "Done!"

--- a/install
+++ b/install
@@ -72,17 +72,21 @@ mkdir -p "$(dirname "${BIN_DESTINATION}")"
 ${DOWNLOAD_CMD} "${BIN_DESTINATION}" "${BIN_URL}"
 info "  Downloading ${ARTIFACT_NAME}... OK"
 
-DIGEST=$(${API_CMD} ${API_URL} | \
+info "  Verifying integrity..."
+API_RESPONSE=$(${API_CMD} ${API_URL}) || {
+  error "Failed to fetch digest from ${API_URL}"
+}
+
+DIGEST=$(echo "${API_RESPONSE}" | \
     grep -A 50 "\"name\": \"${ARTIFACT_NAME}\"" | \
     grep '"digest":' | \
     head -n 1 | \
     sed 's/.*"digest": \([^,]*\).*/\1/'
 )
 
-if [ "$DIGEST" = "null" ]; then
-  warn "This package does have a digest. Cannot perform integrity check."
+if [ "${DIGEST}" = "null" ] || [ -z "${DIGEST}" ]; then
+  warn "This package does not have a digest. Cannot perform integrity check."
 else
-  info "  Verifying integrity..."
   HASH=""
   if command -v sha256sum >/dev/null 2>&1; then
     HASH=$(sha256sum "${BIN_DESTINATION}" | awk '{print $1}')
@@ -92,13 +96,13 @@ else
     error "Neither sha256sum nor shasum found"
   fi
   
-  if [ "\"sha256:$HASH\"" = "$DIGEST" ]; then
-    info "  Verifying integrity... OK"
-  else
+  if [ "\"sha256:$HASH\"" != "$DIGEST" ]; then
     rm -f -- "${BIN_DESTINATION}"
     error "Checksum mismatch. Please reach out at https://github.com/${REPO}/issues to get help"
   fi
 fi
+
+info "  Verifying integrity... OK"
 
 info "  Setting permissions..."
 chmod u+x "${BIN_DESTINATION}"
@@ -152,11 +156,11 @@ fi
 
 if [ -n "$SHELL_CONFIG" ]; then
   if ! grep -Fq "${BIN_ROOT}" "$SHELL_CONFIG"; then
-    printf "\n# Added by ${BIN} installer\n$PATH_LINE" >> "$SHELL_CONFIG"
+    printf "\n# Added by %s installer\n%s\n" "${BIN}" "${PATH_LINE}" >> "$SHELL_CONFIG"
   fi
 
   if [ "$NO_MANPAGE" -eq 0 ] && ! grep -Fq "${MAN_ROOT}" "$SHELL_CONFIG"; then
-    printf "\n# Added by ${BIN} installer\n$MANPATH_LINE" >> "$SHELL_CONFIG"
+    printf "\n# Added by %s installer\n%s\n" "${BIN}" "${MANPATH_LINE}" >> "$SHELL_CONFIG"
   fi
 fi
 info "  Updating shell configuration... OK"

--- a/install
+++ b/install
@@ -7,9 +7,8 @@ MAN_ROOT="$HOME/.local/share/man"
 MAN_SECTION="1"
 
 error() {
-  echo $1 >&2
-  echo "" >&2
-  echo "Usage: REPO=owner/repo BIN=name $0" >&2
+  printf '%s\n\n' "$1" >&2
+  printf 'Usage: REPO=owner/repo BIN=name %s\n' "$0" >&2
   exit 1
 }
 

--- a/install
+++ b/install
@@ -53,7 +53,7 @@ if [ -z "${BIN}" ]; then
 fi
 
 # where to install the binary
-DESTINATION="${BIN_ROOT}/${BIN}"
+BIN_DESTINATION="${BIN_ROOT}/${BIN}"
 # name of the hosted binary
 ARTIFACT_NAME="${BIN}-${OS}-${ARCH}"
 # complete URL where the binary is hosted
@@ -64,7 +64,8 @@ API_URL="https://api.github.com/repos/${REPO}/releases/latest"
 echo "Starting installation of ${BIN}"
 
 echo "  Downloading ${ARTIFACT_NAME}..."
-${DOWNLOAD_CMD} "${DESTINATION}" "${BIN_URL}"
+mkdir -p "$(dirname "${BIN_DESTINATION}")"
+${DOWNLOAD_CMD} "${BIN_DESTINATION}" "${BIN_URL}"
 echo "  Downloading ${ARTIFACT_NAME}... OK"
 
 echo "  Verifying integrity..."
@@ -77,9 +78,9 @@ DIGEST=$(${API_CMD} ${API_URL} | \
 
 HASH=""
 if command -v sha256sum >/dev/null 2>&1; then
-  HASH=$(sha256sum "${DESTINATION}" | awk '{print $1}')
+  HASH=$(sha256sum "${BIN_DESTINATION}" | awk '{print $1}')
 elif command -v shasum >/dev/null 2>&1; then
-  HASH=$(shasum -a 256 "${DESTINATION}" | awk '{print $1}')
+  HASH=$(shasum -a 256 "${BIN_DESTINATION}" | awk '{print $1}')
 else
   error "Neither sha256sum nor shasum found"
 fi
@@ -87,14 +88,13 @@ fi
 if [ "sha256:$HASH" = "$DIGEST" ]; then
   echo "  Verifying integrity... OK"
 else
-  rm ${DESTINATION}
+  rm -f -- "${BIN_DESTINATION}"
   error "Checksum mismatch. Please reach out at https://github.com/${REPO}/issues to get help"
 fi
 
 
 echo "  Setting permissions..."
-chmod u+x "${DESTINATION}"
-chown "$(logname)" "${DESTINATION}"
+chmod u+x "${BIN_DESTINATION}"
 echo "  Setting permissions... OK"
 
 # install the manpage in the first section (user commands and tools)
@@ -111,7 +111,7 @@ fi
 
 if [ "$NO_MANPAGE" -eq 0 ]; then
   echo "  Downloading man page ${MAN_ARTIFACT_NAME}..."
-  mkdir -p "$MAN_ROOT"
+  mkdir -p "$(dirname "${MAN_DESTINATION}")"
   ${DOWNLOAD_CMD} "${MAN_DESTINATION}" "${MAN_URL}"
   echo "  Downloading man page ${MAN_ARTIFACT_NAME}... OK"
 fi

--- a/install
+++ b/install
@@ -47,7 +47,7 @@ if command -v curl >/dev/null 2>&1; then
 elif command -v wget >/dev/null 2>&1; then
     DOWNLOAD_CMD="wget -q -O"
     API_CMD="wget -qO-"
-    HEAD_CMD="wget --spider --max-redirect=20 -q"
+    HEAD_CMD="wget --spider -q"
 else
     error "Either curl or wget is required but neither is installed"
 fi
@@ -112,7 +112,7 @@ MAN_DESTINATION="${MAN_ROOT}/man${MAN_SECTION}/${MAN_ARTIFACT_NAME}"
 MAN_URL="${RELEASE_URL}/download/${MAN_ARTIFACT_NAME}"
 
 NO_MANPAGE=0
-if ! $HEAD_CMD "${MAN_URL}" > /dev/null; then
+if ! $HEAD_CMD "${MAN_URL}" > /dev/null 2>&1; then
   NO_MANPAGE=1
 fi
 

--- a/install
+++ b/install
@@ -6,6 +6,10 @@ BIN_ROOT="$HOME/.local/bin"
 MAN_ROOT="$HOME/.local/share/man"
 MAN_SECTION="1"
 
+info () { printf "%s\\n" "$*" ; }
+
+warn () { printf "WARNING: %s\\n" "$*" ; }
+
 error() {
   printf '%s\n\n' "$1" >&2
   printf 'Usage: REPO=owner/repo BIN=name %s\n' "$0" >&2
@@ -61,41 +65,44 @@ BIN_URL="${RELEASE_URL}/download/${ARTIFACT_NAME}"
 # API URL to fetch the digest
 API_URL="https://api.github.com/repos/${REPO}/releases/latest"
 
-echo "Starting installation of ${BIN}"
+info "Starting installation of ${BIN}"
 
-echo "  Downloading ${ARTIFACT_NAME}..."
+info "  Downloading ${ARTIFACT_NAME}..."
 mkdir -p "$(dirname "${BIN_DESTINATION}")"
 ${DOWNLOAD_CMD} "${BIN_DESTINATION}" "${BIN_URL}"
-echo "  Downloading ${ARTIFACT_NAME}... OK"
+info "  Downloading ${ARTIFACT_NAME}... OK"
 
-echo "  Verifying integrity..."
 DIGEST=$(${API_CMD} ${API_URL} | \
     grep -A 50 "\"name\": \"${ARTIFACT_NAME}\"" | \
     grep '"digest":' | \
     head -n 1 | \
-    sed 's/.*"digest": "\([^"]*\)".*/\1/'
+    sed 's/.*"digest": \([^,]*\).*/\1/'
 )
 
-HASH=""
-if command -v sha256sum >/dev/null 2>&1; then
-  HASH=$(sha256sum "${BIN_DESTINATION}" | awk '{print $1}')
-elif command -v shasum >/dev/null 2>&1; then
-  HASH=$(shasum -a 256 "${BIN_DESTINATION}" | awk '{print $1}')
+if [ "$DIGEST" = "null" ]; then
+  warn "This package does have a digest. Cannot perform integrity check."
 else
-  error "Neither sha256sum nor shasum found"
+  info "  Verifying integrity..."
+  HASH=""
+  if command -v sha256sum >/dev/null 2>&1; then
+    HASH=$(sha256sum "${BIN_DESTINATION}" | awk '{print $1}')
+  elif command -v shasum >/dev/null 2>&1; then
+    HASH=$(shasum -a 256 "${BIN_DESTINATION}" | awk '{print $1}')
+  else
+    error "Neither sha256sum nor shasum found"
+  fi
+  
+  if [ "\"sha256:$HASH\"" = "$DIGEST" ]; then
+    info "  Verifying integrity... OK"
+  else
+    rm -f -- "${BIN_DESTINATION}"
+    error "Checksum mismatch. Please reach out at https://github.com/${REPO}/issues to get help"
+  fi
 fi
 
-if [ "sha256:$HASH" = "$DIGEST" ]; then
-  echo "  Verifying integrity... OK"
-else
-  rm -f -- "${BIN_DESTINATION}"
-  error "Checksum mismatch. Please reach out at https://github.com/${REPO}/issues to get help"
-fi
-
-
-echo "  Setting permissions..."
+info "  Setting permissions..."
 chmod u+x "${BIN_DESTINATION}"
-echo "  Setting permissions... OK"
+info "  Setting permissions... OK"
 
 # install the manpage in the first section (user commands and tools)
 # consequently expect file name to end with .1
@@ -110,13 +117,13 @@ if ! $HEAD_CMD "${MAN_URL}" > /dev/null; then
 fi
 
 if [ "$NO_MANPAGE" -eq 0 ]; then
-  echo "  Downloading man page ${MAN_ARTIFACT_NAME}..."
+  info "  Downloading man page ${MAN_ARTIFACT_NAME}..."
   mkdir -p "$(dirname "${MAN_DESTINATION}")"
   ${DOWNLOAD_CMD} "${MAN_DESTINATION}" "${MAN_URL}"
-  echo "  Downloading man page ${MAN_ARTIFACT_NAME}... OK"
+  info "  Downloading man page ${MAN_ARTIFACT_NAME}... OK"
 fi
 
-echo "  Updating shell configuration..."
+info "  Updating shell configuration..."
 SHELL_CONFIG=""
 PATH_LINE=""
 MANPATH_LINE=""
@@ -145,16 +152,13 @@ fi
 
 if [ -n "$SHELL_CONFIG" ]; then
   if ! grep -Fq "${BIN_ROOT}" "$SHELL_CONFIG"; then
-    echo "" >> "$SHELL_CONFIG"
-    echo "# Added by ${BIN} installer" >> "$SHELL_CONFIG"
-    echo "$PATH_LINE" >> "$SHELL_CONFIG"
+    printf "\n# Added by ${BIN} installer\n$PATH_LINE" >> "$SHELL_CONFIG"
   fi
 
   if [ "$NO_MANPAGE" -eq 0 ] && ! grep -Fq "${MAN_ROOT}" "$SHELL_CONFIG"; then
-    echo "# Added by ${BIN} installer" >> "$SHELL_CONFIG"
-    echo "$MANPATH_LINE" >> "$SHELL_CONFIG"
+    printf "\n# Added by ${BIN} installer\n$MANPATH_LINE" >> "$SHELL_CONFIG"
   fi
 fi
-echo "  Updating shell configuration... OK"
+info "  Updating shell configuration... OK"
 
-echo "Done!"
+info "Done!"

--- a/install
+++ b/install
@@ -176,16 +176,6 @@ if [ -f "$HOME/.profile" ]; then
       "export PATH=\"${BIN_ROOT}:\$PATH\"" \
       "export MANPATH=\"${MAN_ROOT}:\$MANPATH\""
 fi
-
-if [ -n "$SHELL_CONFIG" ]; then
-  if ! grep -Fq "${BIN_ROOT}" "$SHELL_CONFIG"; then
-    printf "\n# %s\n%s\n" "${BIN}" "${PATH_LINE}" >> "$SHELL_CONFIG"
-  fi
-
-  if [ "$NO_MANPAGE" -eq 0 ] && ! grep -Fq "${MAN_ROOT}" "$SHELL_CONFIG"; then
-    printf "\n# %s\n%s\n" "${BIN}" "${MANPATH_LINE}" >> "$SHELL_CONFIG"
-  fi
-fi
 info "  Updating shell configuration... OK"
 
 info "Done!"

--- a/install
+++ b/install
@@ -133,6 +133,14 @@ elif [ -f "$HOME/.bashrc" ]; then
   SHELL_CONFIG="$HOME/.bashrc"
   PATH_LINE="export PATH=\"${BIN_ROOT}:\$PATH\""
   MANPATH_LINE="export MANPATH=\"${MAN_ROOT}:\$MANPATH\""
+elif [ -f "$HOME/.bash_profile" ]; then
+  SHELL_CONFIG="$HOME/.bash_profile"
+  PATH_LINE="export PATH=\"${BIN_ROOT}:\$PATH\""
+  MANPATH_LINE="export MANPATH=\"${MAN_ROOT}:\$MANPATH\""
+elif [ -f "$HOME/.profile" ]; then
+  SHELL_CONFIG="$HOME/.profile"
+  PATH_LINE="export PATH=\"${BIN_ROOT}:\$PATH\""
+  MANPATH_LINE="export MANPATH=\"${MAN_ROOT}:\$MANPATH\""
 fi
 
 if [ -n "$SHELL_CONFIG" ]; then

--- a/install
+++ b/install
@@ -92,7 +92,7 @@ API_RESPONSE=$(${API_CMD} ${API_URL}) || {
 }
 
 DIGEST=$(echo "${API_RESPONSE}" | \
-    grep -A 50 "\"name\": \"${ARTIFACT_NAME}\"" | \
+    grep -A 100 "\"name\": \"${ARTIFACT_NAME}\"" | \
     grep '"digest":' | \
     head -n 1 | \
     sed 's/.*"digest": \([^,]*\).*/\1/'

--- a/install
+++ b/install
@@ -144,13 +144,13 @@ elif [ -f "$HOME/.profile" ]; then
 fi
 
 if [ -n "$SHELL_CONFIG" ]; then
-  if ! grep -q "${BIN_ROOT}" "$SHELL_CONFIG"; then
+  if ! grep -Fq "${BIN_ROOT}" "$SHELL_CONFIG"; then
     echo "" >> "$SHELL_CONFIG"
     echo "# Added by ${BIN} installer" >> "$SHELL_CONFIG"
     echo "$PATH_LINE" >> "$SHELL_CONFIG"
   fi
 
-  if [ "$NO_MANPAGE" -eq 0 ] && ! grep -q "${MAN_ROOT}" "$SHELL_CONFIG"; then
+  if [ "$NO_MANPAGE" -eq 0 ] && ! grep -Fq "${MAN_ROOT}" "$SHELL_CONFIG"; then
     echo "# Added by ${BIN} installer" >> "$SHELL_CONFIG"
     echo "$MANPATH_LINE" >> "$SHELL_CONFIG"
   fi

--- a/install
+++ b/install
@@ -16,6 +16,20 @@ error() {
   exit 1
 }
 
+update_shell_config() {
+  shell_config="$1"
+  path_line="$2"
+  manpath_line="$3"
+
+  if ! grep -Fq "${BIN_ROOT}" "$shell_config"; then
+    printf "\n# Added by %s installer\n%s\n" "${BIN}" "${path_line}" >> "$shell_config"
+  fi
+
+  if [ "$NO_MANPAGE" -eq 0 ] && ! grep -Fq "${MAN_ROOT}" "$shell_config"; then
+    printf "\n# Added by %s installer\n%s\n" "${BIN}" "${manpath_line}" >> "$shell_config"
+  fi
+}
+
 if [ -z "${REPO}" ]; then
   error "REPO should be in the form of 'owner/repo'."
 fi
@@ -116,7 +130,7 @@ MAN_DESTINATION="${MAN_ROOT}/man${MAN_SECTION}/${MAN_ARTIFACT_NAME}"
 MAN_URL="${RELEASE_URL}/download/${MAN_ARTIFACT_NAME}"
 
 NO_MANPAGE=0
-if ! $HEAD_CMD "${MAN_URL}" > /dev/null 2>&1; then
+if ! ${HEAD_CMD} "${MAN_URL}" > /dev/null 2>&1; then
   NO_MANPAGE=1
 fi
 
@@ -128,39 +142,48 @@ if [ "$NO_MANPAGE" -eq 0 ]; then
 fi
 
 info "  Updating shell configuration..."
-SHELL_CONFIG=""
-PATH_LINE=""
-MANPATH_LINE=""
-
 if [ -f "$HOME/.config/fish/config.fish" ]; then
-  SHELL_CONFIG="$HOME/.config/fish/config.fish"
-  PATH_LINE="fish_add_path -g ${BIN_ROOT}"
-  MANPATH_LINE="set -gx MANPATH ${MAN_ROOT} \$MANPATH"
-elif [ -f "$HOME/.zshrc" ]; then
-  SHELL_CONFIG="$HOME/.zshrc"
-  PATH_LINE="export PATH=\"${BIN_ROOT}:\$PATH\""
-  MANPATH_LINE="export MANPATH=\"${MAN_ROOT}:\$MANPATH\""
-elif [ -f "$HOME/.bashrc" ]; then
-  SHELL_CONFIG="$HOME/.bashrc"
-  PATH_LINE="export PATH=\"${BIN_ROOT}:\$PATH\""
-  MANPATH_LINE="export MANPATH=\"${MAN_ROOT}:\$MANPATH\""
-elif [ -f "$HOME/.bash_profile" ]; then
-  SHELL_CONFIG="$HOME/.bash_profile"
-  PATH_LINE="export PATH=\"${BIN_ROOT}:\$PATH\""
-  MANPATH_LINE="export MANPATH=\"${MAN_ROOT}:\$MANPATH\""
-elif [ -f "$HOME/.profile" ]; then
-  SHELL_CONFIG="$HOME/.profile"
-  PATH_LINE="export PATH=\"${BIN_ROOT}:\$PATH\""
-  MANPATH_LINE="export MANPATH=\"${MAN_ROOT}:\$MANPATH\""
+  update_shell_config \
+    "$HOME/.config/fish/config.fish" \
+    "fish_add_path -g ${BIN_ROOT}" \
+    "set -gx MANPATH ${MAN_ROOT} \$MANPATH"
+fi
+
+if [ -f "$HOME/.zshrc" ]; then
+  update_shell_config \
+    "$HOME/.zshrc" \
+    "export PATH=\"${BIN_ROOT}:\$PATH\"" \
+    "export MANPATH=\"${MAN_ROOT}:\$MANPATH\""
+fi
+
+if [ -f "$HOME/.bashrc" ]; then
+  update_shell_config \
+    "$HOME/.bashrc" \
+    "export PATH=\"${BIN_ROOT}:\$PATH\"" \
+    "export MANPATH=\"${MAN_ROOT}:\$MANPATH\""
+fi
+
+if [ -f "$HOME/.bash_profile" ]; then
+    update_shell_config \
+      "$HOME/.bash_profile" \
+      "export PATH=\"${BIN_ROOT}:\$PATH\"" \
+      "export MANPATH=\"${MAN_ROOT}:\$MANPATH\""
+fi
+
+if [ -f "$HOME/.profile" ]; then
+    update_shell_config \
+      "$HOME/.profile" \
+      "export PATH=\"${BIN_ROOT}:\$PATH\"" \
+      "export MANPATH=\"${MAN_ROOT}:\$MANPATH\""
 fi
 
 if [ -n "$SHELL_CONFIG" ]; then
   if ! grep -Fq "${BIN_ROOT}" "$SHELL_CONFIG"; then
-    printf "\n# Added by %s installer\n%s\n" "${BIN}" "${PATH_LINE}" >> "$SHELL_CONFIG"
+    printf "\n# %s\n%s\n" "${BIN}" "${PATH_LINE}" >> "$SHELL_CONFIG"
   fi
 
   if [ "$NO_MANPAGE" -eq 0 ] && ! grep -Fq "${MAN_ROOT}" "$SHELL_CONFIG"; then
-    printf "\n# Added by %s installer\n%s\n" "${BIN}" "${MANPATH_LINE}" >> "$SHELL_CONFIG"
+    printf "\n# %s\n%s\n" "${BIN}" "${MANPATH_LINE}" >> "$SHELL_CONFIG"
   fi
 fi
 info "  Updating shell configuration... OK"

--- a/tests.sh
+++ b/tests.sh
@@ -6,6 +6,9 @@ output="stdout"
 total=0
 failed=0
 
+SUDO=
+[ "$(id -u)" -ne 0 ] && SUDO=sudo
+
 spec() {
   local fn="$1"
 
@@ -38,14 +41,14 @@ test_backward_compatibility_nochecksum_uninstall() {
 }
 
 test_backward_compatibility_withsudo_install() {
-  sudo sh -c "cat ./install | REPO=shikaan/shmux sh -"
+  $SUDO sh -c "cat ./install | REPO=shikaan/shmux sh -"
   [ -f "$HOME/.local/bin/shmux" ]
 }
 
 test_backward_compatibility_withsudo_uninstall() {
   # simulate package present in old location
-  sudo cp "$HOME/.local/bin/shmux" "/usr/local/bin/shmux" 
-  sudo sh -c "cat ./uninstall | REPO=shikaan/shmux sh -"
+  $SUDO cp "$HOME/.local/bin/shmux" "/usr/local/bin/shmux" 
+  $SUDO sh -c "cat ./uninstall | REPO=shikaan/shmux sh -"
   [ ! -f "$HOME/.local/bin/shmux" ]
   [ ! -f "/usr/local/bin/shmux" ]
 }

--- a/tests.sh
+++ b/tests.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env sh
 
-set -u
+set -e
 
 output="stdout"
 total=0
 failed=0
 
 SUDO=
-[ "$(id -u)" -ne 0 ] && SUDO=sudo
+[ "$(id -u)" -ne 0 ] && SUDO="sudo -E"
 
 spec() {
   local fn="$1"

--- a/tests.sh
+++ b/tests.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env sh
+
+set -u
+
+output="stdout"
+total=0
+failed=0
+
+spec() {
+  local fn="$1"
+
+  printf '%s\n' "$fn..."
+  total=$((total + 1))
+  printf "\x1b[2m"
+  if "$fn"; then
+    printf "\x1b[22m"
+    printf '%s\n' "$fn... OK"
+  else
+    printf "\x1b[22m"
+    printf '%s\n' "$fn... FAIL"
+    failed=$((failed + 1))
+  fi
+}
+
+test_backward_compatibility_nochecksum_install() {
+  cat ./install | REPO=shikaan/shmux sh -
+  [ -f "$HOME/.local/bin/shmux" ]
+}
+
+test_backward_compatibility_nochecksum_warning() {
+  cat ./install | REPO=shikaan/shmux sh - > $output
+  [ $(grep -c "WARNING" $output) -eq "1" ]
+}
+
+test_backward_compatibility_nochecksum_uninstall() {
+  cat ./uninstall | REPO=shikaan/shmux sh -
+  [ ! -f "$HOME/.local/bin/shmux" ]
+}
+
+test_backward_compatibility_withsudo_install() {
+  sudo sh -c "cat ./install | REPO=shikaan/shmux sh -"
+  [ -f "$HOME/.local/bin/shmux" ]
+}
+
+test_backward_compatibility_withsudo_uninstall() {
+  # simulate package present in old location
+  sudo cp "$HOME/.local/bin/shmux" "/usr/local/bin/shmux" 
+  sudo sh -c "cat ./uninstall | REPO=shikaan/shmux sh -"
+  [ ! -f "$HOME/.local/bin/shmux" ]
+  [ ! -f "/usr/local/bin/shmux" ]
+}
+
+test_withchecksum_nomanpage() {
+  cat ./install | REPO=shikaan/keydex sh -
+  [ -f "$HOME/.local/bin/keydex" ]
+}
+
+test_withchecksum_nomanpage_nowarning() {
+  cat ./install | REPO=shikaan/keydex sh -
+  cat ./install | REPO=shikaan/keydex sh - > $output
+  [ $(grep -c "WARNING" $output) -eq "0" ]
+}
+
+test_withchecksum_nomanpage_uninstall() {
+  cat ./uninstall | REPO=shikaan/keydex sh -
+  [ ! -f "$HOME/.local/bin/shmux" ]
+}
+
+test_withchecksum_manpage() {
+  cat ./install | REPO=shikaan/lifp sh -
+  [ -f "$HOME/.local/bin/lifp" ] && [ -f "$HOME/.local/share/man/man1/lifp.1" ]
+}
+
+test_withchecksum_manpage_uninstall() {
+  cat ./uninstall | REPO=shikaan/lifp sh -
+  [ ! -f "$HOME/.local/bin/shmux" ] && [ ! -f "$HOME/.local/share/man/man1/lifp.1" ]
+}
+
+specs=$(sed -n 's/^[[:space:]]*\(test_[A-Za-z0-9_]*\)[[:space:]]*()[[:space:]]*{[[:space:]]*$/\1/p' "$0")
+for s in $specs; do
+  spec "$s"
+done
+
+rm -f $output
+printf 'Total: %s, Failed: %s\n' "$total" "$failed"
+exit $failed

--- a/tests.sh
+++ b/tests.sh
@@ -102,7 +102,7 @@ test_withchecksum_manpage() {
   REPO=shikaan/lifp sh - < ./install
   [ -f "$HOME/.local/bin/lifp" ] && \
     [ -f "$HOME/.local/share/man/man1/lifp.1" ] && \
-    has_valid_config ".bashrc" "1"
+    has_valid_config ".bashrc" true
 }
 
 test_withchecksum_manpage_uninstall() {

--- a/tests.sh
+++ b/tests.sh
@@ -14,12 +14,12 @@ spec() {
 
   printf '%s\n' "$fn..."
   total=$((total + 1))
-  printf "\x1b[2m"
+  printf "\033[2m"
   if "$fn"; then
-    printf "\x1b[22m"
+    printf "\033[22m"
     printf '%s\n' "$fn... OK"
   else
-    printf "\x1b[22m"
+    printf "\033[22m"
     printf '%s\n' "$fn... FAIL"
     failed=$((failed + 1))
   fi
@@ -49,7 +49,7 @@ test_backward_compatibility_nochecksum_install() {
 }
 
 test_backward_compatibility_nochecksum_warning() {
-  REPO=shikaan/shmux sh - < ./install > $output
+  REPO=shikaan/shmux sh - < ./install > "$output"
   [ "$(grep -c "WARNING" $output)" -eq "1" ]
 }
 
@@ -78,7 +78,7 @@ test_withchecksum_nomanpage() {
 }
 
 test_withchecksum_nomanpage_nowarning() {
-  REPO=shikaan/keydex sh - < ./install > $output
+  REPO=shikaan/keydex sh - < ./install > "$output"
   [ "$(grep -c "WARNING" $output)" -eq "0" ]
 }
 
@@ -105,6 +105,6 @@ for s in $specs; do
   spec "$s"
 done
 
-rm -f $output
+rm -f "$output"
 printf 'Total: %s, Failed: %s\n' "$total" "$failed"
 exit $failed

--- a/tests.sh
+++ b/tests.sh
@@ -10,7 +10,7 @@ SUDO=
 [ "$(id -u)" -ne 0 ] && SUDO="sudo -E"
 
 spec() {
-  local fn="$1"
+  fn="$1"
 
   printf '%s\n' "$fn..."
   total=$((total + 1))
@@ -25,58 +25,79 @@ spec() {
   fi
 }
 
+config_init() {
+  file="$HOME/$1"
+  rm -f "$file"
+  touch "$file"
+}
+
+has_valid_config() {
+  file="$HOME/$1"
+  manpage="${2:-}"
+
+  grep -Fq "$HOME/.local/bin" "$file" || return 1
+
+  if [ -n "$manpage" ]; then
+    grep -Fq "$HOME/.local/share/man" "$file" || return 1
+  fi
+}
+
 test_backward_compatibility_nochecksum_install() {
-  cat ./install | REPO=shikaan/shmux sh -
-  [ -f "$HOME/.local/bin/shmux" ]
+  config_init ".bashrc"
+  REPO=shikaan/shmux sh - < ./install
+  [ -f "$HOME/.local/bin/shmux" ] && has_valid_config ".bashrc"
 }
 
 test_backward_compatibility_nochecksum_warning() {
-  cat ./install | REPO=shikaan/shmux sh - > $output
-  [ $(grep -c "WARNING" $output) -eq "1" ]
+  REPO=shikaan/shmux sh - < ./install > $output
+  [ "$(grep -c "WARNING" $output)" -eq "1" ]
 }
 
 test_backward_compatibility_nochecksum_uninstall() {
-  cat ./uninstall | REPO=shikaan/shmux sh -
+  REPO=shikaan/shmux sh - < ./uninstall
   [ ! -f "$HOME/.local/bin/shmux" ]
 }
 
 test_backward_compatibility_withsudo_install() {
-  $SUDO sh -c "cat ./install | REPO=shikaan/shmux sh -"
-  [ -f "$HOME/.local/bin/shmux" ]
+  config_init ".bashrc"
+  $SUDO sh -c "REPO=shikaan/shmux sh - < ./install"
+  [ -f "$HOME/.local/bin/shmux" ] && has_valid_config ".bashrc"
 }
 
 test_backward_compatibility_withsudo_uninstall() {
   # simulate package present in old location
-  $SUDO cp "$HOME/.local/bin/shmux" "/usr/local/bin/shmux" 
-  $SUDO sh -c "cat ./uninstall | REPO=shikaan/shmux sh -"
-  [ ! -f "$HOME/.local/bin/shmux" ]
-  [ ! -f "/usr/local/bin/shmux" ]
+  $SUDO cp "$HOME/.local/bin/shmux" "/usr/local/bin/shmux"
+  $SUDO sh -c "REPO=shikaan/shmux sh - < ./uninstall"
+  [ ! -f "$HOME/.local/bin/shmux" ] && [ ! -f "/usr/local/bin/shmux" ]
 }
 
 test_withchecksum_nomanpage() {
-  cat ./install | REPO=shikaan/keydex sh -
-  [ -f "$HOME/.local/bin/keydex" ]
+  config_init ".bashrc"
+  REPO=shikaan/keydex sh - < ./install
+  [ -f "$HOME/.local/bin/keydex" ]  && has_valid_config ".bashrc"
 }
 
 test_withchecksum_nomanpage_nowarning() {
-  cat ./install | REPO=shikaan/keydex sh -
-  cat ./install | REPO=shikaan/keydex sh - > $output
-  [ $(grep -c "WARNING" $output) -eq "0" ]
+  REPO=shikaan/keydex sh - < ./install > $output
+  [ "$(grep -c "WARNING" $output)" -eq "0" ]
 }
 
 test_withchecksum_nomanpage_uninstall() {
-  cat ./uninstall | REPO=shikaan/keydex sh -
-  [ ! -f "$HOME/.local/bin/shmux" ]
+  REPO=shikaan/keydex sh - < ./uninstall
+  [ ! -f "$HOME/.local/bin/keydex" ]
 }
 
 test_withchecksum_manpage() {
-  cat ./install | REPO=shikaan/lifp sh -
-  [ -f "$HOME/.local/bin/lifp" ] && [ -f "$HOME/.local/share/man/man1/lifp.1" ]
+  config_init ".bashrc"
+  REPO=shikaan/lifp sh - < ./install
+  [ -f "$HOME/.local/bin/lifp" ] && \
+    [ -f "$HOME/.local/share/man/man1/lifp.1" ] && \
+    has_valid_config ".bashrc" "1"
 }
 
 test_withchecksum_manpage_uninstall() {
-  cat ./uninstall | REPO=shikaan/lifp sh -
-  [ ! -f "$HOME/.local/bin/shmux" ] && [ ! -f "$HOME/.local/share/man/man1/lifp.1" ]
+  REPO=shikaan/lifp sh - < ./uninstall
+  [ ! -f "$HOME/.local/bin/lifp" ] && [ ! -f "$HOME/.local/share/man/man1/lifp.1" ]
 }
 
 specs=$(sed -n 's/^[[:space:]]*\(test_[A-Za-z0-9_]*\)[[:space:]]*()[[:space:]]*{[[:space:]]*$/\1/p' "$0")

--- a/tests.sh
+++ b/tests.sh
@@ -6,6 +6,16 @@ output="stdout"
 total=0
 failed=0
 
+if [ -z "${CI}" ]; then
+  printf 'WARNING: This will modify files in %s and your shell configuration.\n' "$HOME"
+  printf 'Do you want to continue? [y/N] '
+  read -r answer
+  case "$answer" in
+    y|Y) ;;
+    *) printf 'Aborted.\n'; exit 0 ;;
+  esac
+fi
+
 SUDO=
 [ "$(id -u)" -ne 0 ] && SUDO="sudo -E"
 

--- a/uninstall
+++ b/uninstall
@@ -3,9 +3,8 @@
 set -e
 
 error() {
-  echo $1 >&2
-  echo "" >&2
-  echo "Usage: REPO=owner/repo BIN=name $0" >&2
+  printf '%s\n\n' "$1" >&2
+  printf 'Usage: REPO=owner/repo BIN=name %s\n' "$0" >&2
   exit 1
 }
 

--- a/uninstall
+++ b/uninstall
@@ -1,7 +1,5 @@
 #!/usr/bin/env sh
 
-set -e
-
 info () { printf "%s\\n" "$*" ; }
 
 warn () { printf "WARNING: %s\\n" "$*" ; }
@@ -13,7 +11,7 @@ error() {
 }
 
 if [ -z "${REPO}" ]; then
-  error "REPO should be in the form of 'organization/repo', got '${REPO}'."
+  error "REPO should be in the form of 'owner/repo', got '${REPO}'."
 fi
 
 if [ -z "${BIN}" ]; then

--- a/uninstall
+++ b/uninstall
@@ -28,7 +28,7 @@ MAN_DESTINATION="${MAN_ROOT}/man${MAN_SECTION}/${MAN_ARTIFACT_NAME}"
 DESTINATION="${BIN_ROOT}/${BIN}"
 
 if [ "$(id -u)" -ne 0 ]; then
-  warn "Uninstalling for the current user only. If you want to uninstall for all, run 'sudo $0'."
+  warn "Uninstalling for the current user only. If you want to uninstall for all, run with sudo."
 fi
 
 info "Starting uninstallation of ${BIN}"

--- a/uninstall
+++ b/uninstall
@@ -2,6 +2,10 @@
 
 set -e
 
+info () { printf "%s\\n" "$*" ; }
+
+warn () { printf "WARNING: %s\\n" "$*" ; }
+
 error() {
   printf '%s\n\n' "$1" >&2
   printf 'Usage: REPO=owner/repo BIN=name %s\n' "$0" >&2
@@ -24,14 +28,11 @@ MAN_DESTINATION="${MAN_ROOT}/man${MAN_SECTION}/${MAN_ARTIFACT_NAME}"
 DESTINATION="${BIN_ROOT}/${BIN}"
 
 if [ "$(id -u)" -ne 0 ]; then
-  echo ""
-  echo "WARNING: This will only uninstall for the current user."
-  echo "         If you want to run a system-wide uninstallation, run 'sudo $0'."
-  echo ""
+  warn "Uninstalling for the current user only. If you want to uninstall for all, run 'sudo $0'."
 fi
 
-echo "Starting uninstallation of ${BIN}"
-echo "  Removing binaries and manpages..."
+info "Starting uninstallation of ${BIN}"
+info "  Removing binaries and manpages..."
 rm -f "${DESTINATION}"
 rm -f "${MAN_DESTINATION}"
 
@@ -41,6 +42,6 @@ if [ "$(id -u)" -eq 0 ]; then
   rm -f "/usr/local/share/man/man1/${BIN}.1"
 fi
 
-echo "  Removing binaries and manpages... OK"
+info "  Removing binaries and manpages... OK"
 
-echo "Done!"
+info "Done!"

--- a/uninstall
+++ b/uninstall
@@ -1,28 +1,47 @@
 #!/usr/bin/env sh
 
-print_usage () {
-  echo ""
-  echo "Usage: sudo REPO=org/repo BIN=name $0"
+set -e
+
+error() {
+  echo $1 >&2
+  echo "" >&2
+  echo "Usage: REPO=owner/repo BIN=name $0" >&2
+  exit 1
 }
 
-if [ "$(id -u)" -ne 0 ]; then
-  echo "Uninstallation needs to be run as super user. Please run 'sudo $0' to proceed."
-  exit 1
-fi
-
 if [ -z "${REPO}" ]; then
-  echo "REPO should be in the form of 'organization/repo', got '${REPO}'."
-  print_usage
-  exit 1
+  error "REPO should be in the form of 'organization/repo', got '${REPO}'."
 fi
 
 if [ -z "${BIN}" ]; then
   BIN=$(basename "${REPO}")
 fi
 
+BIN_ROOT="$HOME/.local/bin"
+MAN_ROOT="$HOME/.local/share/man"
+MAN_SECTION="1"
+MAN_ARTIFACT_NAME="${BIN}.${MAN_SECTION}"
+MAN_DESTINATION="${MAN_ROOT}/man${MAN_SECTION}/${MAN_ARTIFACT_NAME}"
+DESTINATION="${BIN_ROOT}/${BIN}"
 
-echo "Removing previous installation of ${BIN}"
-rm "/usr/local/bin/${BIN}"
-rm -f "/usr/local/share/man/man1/${BIN}.1"
+if [ "$(id -u)" -ne 0 ]; then
+  echo ""
+  echo "WARNING: This will only uninstall for the current user."
+  echo "         If you want to run a system-wide uninstallation, run 'sudo $0'."
+  echo ""
+fi
+
+echo "Starting uninstallation of ${BIN}"
+echo "  Removing binaries and manpages..."
+rm -f "${DESTINATION}"
+rm -f "${MAN_DESTINATION}"
+
+# check previous installations (the sudo ones) and attempt cleaning
+if [ "$(id -u)" -eq 0 ]; then
+  rm -f "/usr/local/bin/${BIN}"
+  rm -f "/usr/local/share/man/man1/${BIN}.1"
+fi
+
+echo "  Removing binaries and manpages... OK"
 
 echo "Done!"


### PR DESCRIPTION
This PR includes a bunch of security updates to these scripts. Specifically, it stops requiring users to `sudo` their installations and introduces an integrity check, whenever possible, to the resolved artifacts.

**Key Changes**
- **Installer/Uninstaller**: Now installs to user-local directories (`~/.local/bin` and `~/.local/share/man`), adds checksum verification, and auto-updates shell configs. Removed `sudo` requirement.
- **Testing**: Added GitHub Actions workflow and comprehensive `tests.sh` script for automated testing across Ubuntu and macOS.
- **Documentation**: Updated README with new installation commands.
- **Other**: Updated LICENSE copyright year.
----

This change is expected to be fully backward compatible. Existing scripts should still be working
